### PR TITLE
Fixed pagination bug on individual push

### DIFF
--- a/app/sae/design/desktop/flat/template/push/application/edit.phtml
+++ b/app/sae/design/desktop/flat/template/push/application/edit.phtml
@@ -337,7 +337,7 @@ $googlemaps_key = $api->getSecretKey();
                                             <?php if(empty($customer["registration_id"]) AND empty($customer["device_uid"])): ?>
                                                 <span title="<?php echo $this->_("No device found for this user"); ?>">X</span>
                                             <?php else: ?>
-                                                <input type="checkbox" class="checkbox chk_customers" id="<?php echo $customer["customer_id"]; ?>" value="<?php echo $customer["customer_id"]; ?>" />
+                                                <input type="checkbox" class="checkbox chk_customers" onclick="handleClick(this);" id="<?php echo $customer["customer_id"]; ?>" value="<?php echo $customer["customer_id"]; ?>" />
                                             <?php endif; ?>
                                         </td>
                                         <td><?php echo $customer["email"]; ?></td>
@@ -459,6 +459,7 @@ $googlemaps_key = $api->getSecretKey();
 
         var default_cover_url = '<?php echo $messageobj->getCoverUrl(); ?>';
         var img_uploader = new Uploader();
+        var customers_list = new Array();
 
         page.setCallback('didappear', function() {
 
@@ -724,13 +725,13 @@ $googlemaps_key = $api->getSecretKey();
                         }
 
                         /** Individual Push */
-                        var customers = new Array();
+                        /*var customers = new Array();
                         $(".chk_customers").each(function(index,elem) {
                             if($(elem).is(':checked')) {
                                 customers.push($(elem).val());
                             }
-                        });
-                        id_string = customers.join(";");
+                        });*/
+                        id_string = customers_list.join(";");
 
                         $("#customers_receiver").val(id_string);
 
@@ -820,6 +821,21 @@ $googlemaps_key = $api->getSecretKey();
 
             deleteMessage(msgid);
         });
+        
+        function handleClick (customer){
+
+            var customer_id = $(customer).attr('id');
+            
+            if(customer.checked){
+                customers_list.push(customer_id);
+            }else {
+                var index = customers_list.indexOf(customer_id);
+
+                if (index > -1) {
+                    customers_list.splice(index, 1);
+                }
+            }
+        }
 
     </script>
     <link href="/app/sae/design/desktop/flat/template/push/application/edit.css" media="screen" rel="stylesheet" type="text/css">


### PR DESCRIPTION
To reproduce the pagination bug for the individual push section there are the following steps:

- New Push
- Send to a specific customer
- Select one customer in table page 1 and another in table page 2
- When you send the push, you will notice that the user selected is only the user in table page 2

With this fix, the user is selected/removed when I click on the checkbox and not when I click for the next step of the push wizard.