### PR TITLE
Siberian/View.php: Remove redundant call to getPartialHtml

### DIFF
--- a/lib/Siberian/View.php
+++ b/lib/Siberian/View.php
@@ -86,7 +86,6 @@ class Siberian_View extends Zend_View
     }
 
     public function getPartialHtml($key) {
-        $this->getLayout()->getPartialHtml($key);
         return $this->getLayout()->getPartialHtml($key);
     }
 


### PR DESCRIPTION
I'm not sure this removal does not break anything, but it looks suspicious.
I think siberian works fine even with this change.